### PR TITLE
fixed type with inventory model

### DIFF
--- a/app/models/character_inventory.py
+++ b/app/models/character_inventory.py
@@ -11,4 +11,4 @@ character_inventory = db.Table(
 )
 
 if environment == "production":
-    character_skills.schema = SCHEMA
+    character_inventory.schema = SCHEMA


### PR DESCRIPTION
Fixed typo in character inventory model where it said 'character_skills' instead of 'character inventory'.